### PR TITLE
Fix case of bool type output

### DIFF
--- a/odata.py
+++ b/odata.py
@@ -96,6 +96,14 @@ from xml.sax.saxutils import escape
 def format_date_for_tableau(d):
     return d.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
+# I think lowercase "true" and "false" may be OData standard anyway,
+# certainly it is all Tableau accepts.
+def format_bool_for_tableau(value):
+    if value:
+        return "true"
+    else:
+        return "false"
+
 def make_cells(cells):
     result = []
     for key, value in cells.items():
@@ -115,6 +123,9 @@ def make_cells(cells):
 
         if type(value) == datetime:
             value = format_date_for_tableau(value)
+
+        if type(value) == bool:
+            value = format_bool_for_tableau(value)
 
         yield form.format(
             safe_name=key,

--- a/test_odata.py
+++ b/test_odata.py
@@ -41,3 +41,17 @@ def test_make_cells_datetime_natural():
     # Tableau 8.2 accepts.
     assert_in('<d:humbug m:type="Edm.DateTimeOffset">2008-11-24T15:11:49.000000Z</d:humbug>', result)
 
+def test_make_cells_boolean():
+    fixture = {
+        "apple": True,
+        "orange": False
+    }
+    cells = odata.make_cells(fixture)
+    (result1,result2) = sorted(cells)
+    # This exact format - with milliseconds, and Z as timezone - is only one
+    # Tableau 8.2 accepts.
+    assert_in('<d:apple m:type="Edm.Boolean">true</d:apple>', result1)
+    assert_in('<d:orange m:type="Edm.Boolean">false</d:orange>', result2)
+
+
+


### PR DESCRIPTION
So it works in Tableau, lowercase "true" and "false" instead of with initial
capital.
