### PR TITLE
Make it work for tables with "id" column

### DIFF
--- a/odata.py
+++ b/odata.py
@@ -181,7 +181,7 @@ def render(api_server, api_path, collection, entries,
 
 
 def build_odata(table, collection, offset=0, limit=100000, skip_token=None):
-    records = select(["rowid", table])
+    records = select(["rowid as rowid", table])
     record_count_total = records.count().scalar()
 
     records = records.offset(offset).limit(limit)


### PR DESCRIPTION
SQLite aliases "rowid" to "id" automatically if there is
an autoincrementing column "id". It also changes the label
by default to "id", confusing our code. If you do
"rowid as rowid" in the select, this forces the label we expect.

Should fix https://github.com/scraperwiki/odata-cgi/issues/5
