### PR TITLE
Escape column names correctly

### DIFF
--- a/odata.py
+++ b/odata.py
@@ -95,16 +95,21 @@ from xml.sax.saxutils import escape
 # XXX not clear SQLAlchemy is returning the correctly timezoned data.
 # This works for Twitter data as in UTC, needs testing more on other
 # timezone data. For now, better than whole thing being broken.
+
+
 def format_date_for_tableau(d):
     return d.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 # I think lowercase "true" and "false" may be OData standard anyway,
 # certainly it is all Tableau accepts.
+
+
 def format_bool_for_tableau(value):
     if value:
         return "true"
     else:
         return "false"
+
 
 def make_cells(cells):
     result = []
@@ -256,7 +261,8 @@ app.url_map.strict_slashes = False
 
 @app.route(api_path + "/<collection>/")
 def show_collection(collection):
-    log.info("show_collection({}) req args {}".format(collection, request.args))
+    log.info("show_collection({}) req args {}"
+             .format(collection, request.args))
 
     engine = create_engine('sqlite:////home/scraperwiki.sqlite')
     m = MetaData(engine)


### PR DESCRIPTION
It turns out we forgot to escape column names. 

This should fix things..
